### PR TITLE
added functions to fix issue #31, /repeat channels

### DIFF
--- a/pybot/endpoints/slack/commands.py
+++ b/pybot/endpoints/slack/commands.py
@@ -21,6 +21,7 @@ def create_endpoints(plugin: SlackPlugin):
     plugin.on_command('/here', slash_here, wait=False)
     plugin.on_command('/lunch', slash_lunch, wait=False)
     plugin.on_command('/repeat', slash_repeat, wait=False)
+    plugin.on_command('/repeat channels', slash_repeat_channels, wait=False)
 
 
 async def slash_here(command: dict, app):
@@ -79,4 +80,13 @@ async def slash_repeat(command: dict, app):
     slack = app["plugins"]["slack"].api
 
     method_type, message = get_slash_repeat_messages(slack_id, channel_id, command['text'])
+    await slack.query(method_type, message)
+
+
+async def slash_repeat_channels(command: dict, app):
+    channel_id = command['channel_id']
+    slack_id = command['user_id']
+    slack = app["plugins"]["slack"].api
+
+    method_type, message = get_slash_repeat_channels_messages(slack_id, channel_id, command['text'])
     await slack.query(method_type, message)

--- a/pybot/endpoints/slack/utils/command_utils.py
+++ b/pybot/endpoints/slack/utils/command_utils.py
@@ -16,3 +16,14 @@ def get_slash_repeat_messages(user_id, channel, text):
 
     values_dict = repeat_items(text, user_id, channel)
     return response_type[values_dict['type']], values_dict['message']
+
+
+def get_slash_repeat_channels_messages(user_id, channel):
+    response_type = {'ephemeral': methods.CHAT_POST_EPHEMERAL,
+                     'message': methods.CHAT_POST_MESSAGE}
+
+    url = 'https://github.com/OperationCode/operationcode_docs/blob/master/community/slack_channel_guide.md'
+    message = f':exclamation:Channel Guide :exclamation: {url}'
+    values_dict = {'type': 'ephemeral',
+                'message': {'channel': channel, 'user': user_id, 'text': message}}
+    return response_type[values_dict['type']], values_dict['message']


### PR DESCRIPTION
I do not know how to test a Slackbot locally, so I was unable to test these changes. I added a `get_slash_repeat_channels_messages` function to `command_utils.py` and a `slash_repeat_channels` function to `commands.py` to return the link to the Channels Guide. I hope these help. Thanks.