### PR TITLE
Update the URL for slash repeat resources

### DIFF
--- a/pybot/endpoints/slack/utils/slash_repeat.py
+++ b/pybot/endpoints/slack/utils/slash_repeat.py
@@ -3,7 +3,7 @@ from typing import Iterable
 
 # TODO: use the github api to find the file even if location changes
 def find_resources() -> dict:
-    return {'link': 'https://github.com/OperationCode/resources_api/blob/master/db_setup/resources.yml',
+    return {'link': 'https://github.com/OperationCode/resources_api/blob/master/resources.yml',
             'title': 'A big list of resources',
             'pretext': 'Would you like some resources.yml?'}
 


### PR DESCRIPTION
We moved the `resources.yml` file in the other repo and now the slash command is out of date. This corrects the URL.