### PR TITLE
Keep message in details form

### DIFF
--- a/pybot/endpoints/slack/actions/mentor_request.py
+++ b/pybot/endpoints/slack/actions/mentor_request.py
@@ -53,8 +53,10 @@ async def mentor_details_submit(action: Action, app: SirBot):
 
 
 async def open_details_dialog(action: Action, app: SirBot):
+    request = MentorRequest(action)
+    cur_details = request.details
     trigger_id = action["trigger_id"]
-    response = {"trigger_id": trigger_id, "dialog": mentor_details_dialog(action)}
+    response = {"trigger_id": trigger_id, "dialog": mentor_details_dialog(action, cur_details)}
     await app.plugins["slack"].api.query(methods.DIALOG_OPEN, response)
 
 

--- a/pybot/endpoints/slack/utils/action_messages.py
+++ b/pybot/endpoints/slack/utils/action_messages.py
@@ -252,7 +252,7 @@ def build_report_message(slack_id, details, message_details):
     return {"text": message, "channel": MODERATOR_CHANNEL, "attachments": attachment}
 
 
-def mentor_details_dialog(action):
+def mentor_details_dialog(action, cur_details):
     trigger_id = action["trigger_id"]
     ts = action["message"]["ts"]
 
@@ -269,6 +269,7 @@ def mentor_details_dialog(action):
                 "name": "details",
                 "placeholder": "",
                 "required": False,
+                "value": cur_details
             }
         ],
     }


### PR DESCRIPTION
When you make a mentor request and click the `Add Details` button, it pops up with an empty modal. This is fine when you click it the first time, but if you want to go back and edit what you wrote, it pops up with an empty modal still, rather than remembering what details you put in already. This PR allows for the details to be pre-populated in the modal upon subsequent clicks of the `Add Details` button.