### PR TITLE
Add value to dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,18 @@
   <a href="https://operationcode.org">
     <img
       alt="Operation Code Hacktoberfest Banner"
-      src="https://s3.amazonaws.com/operationcode-assets/branding/logos/large-blue-logo.png"
+      src="https://operation-code-assets.s3.us-east-2.amazonaws.com/operation_code_hacktoberfest_2019.jpg"
     >
   </a>
   <br />
   <br />
 </div>
+
+# 🎃 Hacktoberfest 🎃
+
+[All the details you need](https://github.com/OperationCode/START_HERE/blob/master/README.md#-hacktoberfest-) before participating with us.
+
+<br />
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Twitter Follow](https://img.shields.io/twitter/follow/operation_code.svg?style=social&label=Follow&style=social)](https://twitter.com/operation_code)

--- a/pybot/endpoints/slack/actions/mentor_request.py
+++ b/pybot/endpoints/slack/actions/mentor_request.py
@@ -53,8 +53,10 @@ async def mentor_details_submit(action: Action, app: SirBot):
 
 
 async def open_details_dialog(action: Action, app: SirBot):
+    request = MentorRequest(action)
+    cur_details = request.details
     trigger_id = action["trigger_id"]
-    response = {"trigger_id": trigger_id, "dialog": mentor_details_dialog(action)}
+    response = {"trigger_id": trigger_id, "dialog": mentor_details_dialog(action, cur_details)}
     await app.plugins["slack"].api.query(methods.DIALOG_OPEN, response)
 
 

--- a/pybot/endpoints/slack/utils/action_messages.py
+++ b/pybot/endpoints/slack/utils/action_messages.py
@@ -252,7 +252,7 @@ def build_report_message(slack_id, details, message_details):
     return {"text": message, "channel": MODERATOR_CHANNEL, "attachments": attachment}
 
 
-def mentor_details_dialog(action):
+def mentor_details_dialog(action, cur_details):
     trigger_id = action["trigger_id"]
     ts = action["message"]["ts"]
 
@@ -269,6 +269,7 @@ def mentor_details_dialog(action):
                 "name": "details",
                 "placeholder": "",
                 "required": False,
+                "value": cur_details
             }
         ],
     }


### PR DESCRIPTION
When you make a mentor request and click the Add Details button, it pops up with an empty modal. This is fine when you click it the first time, but if you want to go back and edit what you wrote, it pops up with an empty modal still, rather than remembering what details you put in already. This PR allows for the details to be pre-populated in the modal upon subsequent clicks of the Add Details button.