### PR TITLE
Add instructions for enabling slack events

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ example:
 
     https://123_random_code_321.ngrok.io/slack/events
 
+In the section that says "Subscribe to events on behalf of users", you must add the following events:
+
+Event Name | Scope
+------- | -----------
+message.channels | channels:history
+
+Once you have set your Event subscription URL and given it the proper scope, you should now be able to use event commands such as `!tech`
+
 #### Slash Commands
 
 You can follow the instructions (and read helpful relation information) on the


### PR DESCRIPTION
While trying to review #233 I wasn't sure how to enable events to try out `!tech` and `!search` in my dev environment. After playing around with it, I figured it out. This documents how to set it up.

@AllenAnthes Can you please check staging or prod to find out if there is more events that we're subscribed to? I'd like to let people set up all of their scopes at once rather than piecemeal because you have to reinstall the app when you change these permissions. `message.channels` is the only one that I needed for `!tech` as far as I can tell.