### PR TITLE
Delayed "Call To Action" message created for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,4 @@ BOT_USER_OAUTH_ACCESS_TOKEN | The bot user specific OAuth token used to authenti
 
 ## License
 This package is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+

--- a/pybot/endpoints/slack/commands.py
+++ b/pybot/endpoints/slack/commands.py
@@ -111,9 +111,7 @@ async def slash_repeat(command: Command, app: SirBot):
     slack = app["plugins"]["slack"].api
     arguments = command["text"].split(" ")
 
-    method_type, message = get_slash_repeat_messages(
-        slack_id, channel_id, arguments
-    )
+    method_type, message = get_slash_repeat_messages(slack_id, channel_id, arguments)
 
     await slack.query(method_type, message)
 

--- a/pybot/endpoints/slack/events.py
+++ b/pybot/endpoints/slack/events.py
@@ -47,6 +47,7 @@ async def team_join(event: Event, app: SirBot) -> None:
     if headers:
         await link_backend_user(user_id, headers, slack_api, app.http_session)
 
+
 async def team_join_delayed(event: Event, app: SirBot) -> None:
     """
     Handler for when the Slack workspace has a new member join.
@@ -57,8 +58,8 @@ async def team_join_delayed(event: Event, app: SirBot) -> None:
     user_id = event["user"]["id"]
 
     social_media_messages = build_delayed_messages(user_id)
-    future = [ send_social_cta(social_media_messages, slack_api) ]
+    future = [send_social_cta(social_media_messages, slack_api)]
 
     logger.info(f"Scheduling delayed message")
-    await asyncio.sleep(60)
+    await asyncio.sleep(900)
     await asyncio.wait(future)

--- a/pybot/endpoints/slack/events.py
+++ b/pybot/endpoints/slack/events.py
@@ -10,6 +10,8 @@ from pybot.endpoints.slack.utils.event_utils import (
     link_backend_user,
     send_community_notification,
     send_user_greetings,
+    build_delayed_messages,
+    send_social_cta,
 )
 
 logger = logging.getLogger(__name__)
@@ -17,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 def create_endpoints(plugin):
     plugin.on_event("team_join", team_join, wait=False)
+    plugin.on_event("team_join", team_join_delayed, wait=False)
 
 
 async def team_join(event: Event, app: SirBot) -> None:
@@ -43,3 +46,19 @@ async def team_join(event: Event, app: SirBot) -> None:
     headers = await get_backend_auth_headers(app.http_session)
     if headers:
         await link_backend_user(user_id, headers, slack_api, app.http_session)
+
+async def team_join_delayed(event: Event, app: SirBot) -> None:
+    """
+    Handler for when the Slack workspace has a new member join.
+
+    After 1 day sends the new user a greeting, a call to action to join social media
+    """
+    slack_api = app.plugins["slack"].api
+    user_id = event["user"]["id"]
+
+    social_media_messages = build_delayed_messages(user_id)
+    future = [ send_social_cta(social_media_messages, slack_api) ]
+
+    logger.info(f"Scheduling delayed message")
+    await asyncio.sleep(60)
+    await asyncio.wait(future)

--- a/pybot/endpoints/slack/utils/event_messages.py
+++ b/pybot/endpoints/slack/utils/event_messages.py
@@ -25,6 +25,28 @@ def second_team_join_message() -> str:
     )
 
 
+def third_team_join_message() -> str:
+    return f"If this is your first time using Slack, please watch this <https://youtu.be/m2JuAa6-ors|short tutorial> to get familiar with the app."
+
+
+def delayed_team_join_message() -> str:
+    return (
+        f"Welcome to Operation Code's Slack Community, we're glad you're here! "
+        f"Please share with us in #general what brings you to Operation Code, "
+        f"and how we can assist you. Also, consider adding to your Operation Code "
+        f"profile the links to your LinkedIn and GitHub accounts. "
+        f"Lastly, consider connecting with us on our social media accounts: "
+        f"<https://www.facebook.com/operationcode.org/|Facebook>, "
+        f"<https://twitter.com/operation_code|Twitter>, "
+        f"<https://business.linkedin.com/marketing-solutions/higher-education|LinkedIn>, "
+        f"<https://www.instagram.com/operation_code/?hl=en|Instagram> and "
+        f"<https://www.youtube.com/channel/UCAoJt4a_KEBmgXfoQUrNbSA/featured?view_as=public|YouTube>"
+        f", and contribute to our open source platform on "
+        f"<https://github.com/OperationCode|GitHub>. If you have any immediate needs, "
+        f"please tag our @outreach-team in any public channel. "
+    )
+
+
 def external_button_attachments() -> List[dict]:
     return [
         {

--- a/pybot/endpoints/slack/utils/event_utils.py
+++ b/pybot/endpoints/slack/utils/event_utils.py
@@ -66,6 +66,27 @@ def build_messages(user_id) -> Tuple[Message, Message, Message, Message, Message
         outreach_team_message,
     )
 
+def build_delayed_messages(user_id) -> Tuple[Message]:
+    social_media_message = base_user_message(user_id)
+    social_media_message["text"] = (
+        f"Welcome to Operation Code's Slack Community, we're glad you're here! "
+        f"Please share with us in #general what brings you to Operation Code, "
+        f"and how we can assist you. Also, consider adding to your Operation Code "
+        f"profile the links to your LinkedIn and GitHub accounts. "
+        f"Lastly, consider connecting with us on our social media accounts: "
+        f"<a href='https://www.facebook.com/operationcode.org/'>Facebook</a>, "
+        f"<a href='https://twitter.com/operation_code'>Twitter</a>, "
+        f"<a href='https://business.linkedin.com/marketing-solutions/higher-education'>LinkedIn</a>, "
+        f"<a href='https://www.instagram.com/operation_code/?hl=en'>Instagram</a> and "
+        f"<a href='https://www.youtube.com/channel/UCAoJt4a_KEBmgXfoQUrNbSA/featured?view_as=public'>YouTube</a>"
+        f", and contribute to our open source platform on "
+        f"<a href='https://github.com/OperationCode'>GitHub</a>. If you have any immediate needs, "
+        f"please tag our @outreach-team in any public channel. "
+    )
+
+    return (
+        social_media_message,
+    )
 
 async def send_user_greetings(
     user_messages: List[Message], slack_api: SlackAPI
@@ -79,6 +100,11 @@ async def send_community_notification(
 ) -> dict:
     return await slack_api.query(url=methods.CHAT_POST_MESSAGE, data=community_message)
 
+async def send_social_cta(
+   social_media_messages: List[Message], slack_api: SlackAPI
+) -> None:
+    for message in social_media_messages:
+        await slack_api.query(url=methods.CHAT_POST_MESSAGE, data=message)
 
 async def link_backend_user(
     slack_id: str,

--- a/pybot/endpoints/slack/utils/event_utils.py
+++ b/pybot/endpoints/slack/utils/event_utils.py
@@ -21,6 +21,8 @@ from pybot.endpoints.slack.utils.event_messages import (
     external_button_attachments,
     second_team_join_message,
     team_join_initial_message,
+    delayed_team_join_message,
+    third_team_join_message,
 )
 
 logger = logging.getLogger(__name__)
@@ -33,13 +35,18 @@ def base_user_message(user_id: str) -> Message:
     return message
 
 
-def build_messages(user_id) -> Tuple[Message, Message, Message, Message, Message]:
+def build_messages(
+    user_id,
+) -> Tuple[Message, Message, Message, Message, Message, Message]:
     initial_message = base_user_message(user_id)
     initial_message["text"] = team_join_initial_message(user_id)
 
     second_message = base_user_message(user_id)
     second_message["text"] = second_team_join_message()
     second_message["attachments"] = external_button_attachments()
+
+    third_message = base_user_message(user_id)
+    third_message["text"] = third_team_join_message()
 
     action_menu = base_user_message(user_id)
     action_menu["text"] = "We recommend the following resources."
@@ -61,32 +68,19 @@ def build_messages(user_id) -> Tuple[Message, Message, Message, Message, Message
     return (
         initial_message,
         second_message,
+        third_message,
         action_menu,
         community_message,
         outreach_team_message,
     )
 
+
 def build_delayed_messages(user_id) -> Tuple[Message]:
     social_media_message = base_user_message(user_id)
-    social_media_message["text"] = (
-        f"Welcome to Operation Code's Slack Community, we're glad you're here! "
-        f"Please share with us in #general what brings you to Operation Code, "
-        f"and how we can assist you. Also, consider adding to your Operation Code "
-        f"profile the links to your LinkedIn and GitHub accounts. "
-        f"Lastly, consider connecting with us on our social media accounts: "
-        f"<a href='https://www.facebook.com/operationcode.org/'>Facebook</a>, "
-        f"<a href='https://twitter.com/operation_code'>Twitter</a>, "
-        f"<a href='https://business.linkedin.com/marketing-solutions/higher-education'>LinkedIn</a>, "
-        f"<a href='https://www.instagram.com/operation_code/?hl=en'>Instagram</a> and "
-        f"<a href='https://www.youtube.com/channel/UCAoJt4a_KEBmgXfoQUrNbSA/featured?view_as=public'>YouTube</a>"
-        f", and contribute to our open source platform on "
-        f"<a href='https://github.com/OperationCode'>GitHub</a>. If you have any immediate needs, "
-        f"please tag our @outreach-team in any public channel. "
-    )
+    social_media_message["text"] = delayed_team_join_message()
 
-    return (
-        social_media_message,
-    )
+    return (social_media_message,)
+
 
 async def send_user_greetings(
     user_messages: List[Message], slack_api: SlackAPI
@@ -100,11 +94,13 @@ async def send_community_notification(
 ) -> dict:
     return await slack_api.query(url=methods.CHAT_POST_MESSAGE, data=community_message)
 
+
 async def send_social_cta(
-   social_media_messages: List[Message], slack_api: SlackAPI
+    social_media_messages: List[Message], slack_api: SlackAPI
 ) -> None:
     for message in social_media_messages:
         await slack_api.query(url=methods.CHAT_POST_MESSAGE, data=message)
+
 
 async def link_backend_user(
     slack_id: str,

--- a/pybot/endpoints/slack/utils/slash_repeat.py
+++ b/pybot/endpoints/slack/utils/slash_repeat.py
@@ -36,7 +36,11 @@ def modify_params(modify_options: dict) -> dict:
         ],
     }
 
-    message["attachments"][0]["pretext"] = f'<{modify_options["arguments"][1]}>: {modify_options["pretext"]} (sent by: <@{modify_options["slack_id"]}>)' if len(modify_options["arguments"]) >= 2 else f'<@{modify_options["slack_id"]}>: {modify_options["pretext"]}'
+    message["attachments"][0]["pretext"] = (
+        f'<{modify_options["arguments"][1]}>: {modify_options["pretext"]} (sent by: <@{modify_options["slack_id"]}>)'
+        if len(modify_options["arguments"]) >= 2
+        else f'<@{modify_options["slack_id"]}>: {modify_options["pretext"]}'
+    )
     message["attachments"][0]["title_link"] = modify_options["link"]
 
     return message


### PR DESCRIPTION
## Description

Three new functions created: team_join_delayed,  build_delayed_message, and send_social_cta. 

60 seconds after a user signs up for a new account, they will receive a private message from the slackbot with a welcome message and a request to the user to follow OC on social media. 

team_join_delayed calls build_delayed_message to create social_media_messages, which is passed to send_social_cta. 

## Motivation and Context

The purpose of this PR is to allow new users the opportunity to get acquainted with the OC slack channel, then give the user the information they need to learn more about OC in other social media forums. 

## How has this been tested?

This feature was tested by creating several new user accounts in the OC dev slack channel, and successfully received the delayed message 60 seconds after new user account creation

## Type of Change

This is a new feature that adds additional functionality




