### PR TITLE
Fix #301 - Send acknowledgement message to reporters

### DIFF
--- a/pybot/endpoints/slack/commands.py
+++ b/pybot/endpoints/slack/commands.py
@@ -79,6 +79,13 @@ async def slash_report(command: Command, app: SirBot):
 
     await slack.query(methods.CHAT_POST_MESSAGE, response)
 
+    ack = {
+        "text": f"Your report has been submitted successfully. The moderation team will review. Your Report:\n\n{message}",
+        "channel": slack_id,
+    }
+
+    await slack.query(methods.CHAT_POST_MESSAGE, ack)
+
 
 @catch_command_slack_error
 async def slash_lunch(command: Command, app: SirBot):


### PR DESCRIPTION
Sends a DM to the user indicating that their report was received successfully, along with the text of the report as a receipt.


<img width="1081" alt="Screen Shot 2021-12-17 at 3 29 23 PM" src="https://user-images.githubusercontent.com/2008701/146610158-7f0b2828-1f99-4128-9e5e-ad0bdc3abdb4.png">

CC: @ancipolla

