### PR TITLE
Update ECR to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@4.0.1
+  aws-ecr: circleci/aws-ecr@7.3.0
   aws-ecs: circleci/aws-ecs@0.0.8
   docker: circleci/docker@0.5.1
 
@@ -32,7 +32,7 @@ workflows:
 
 
       # push new Docker image to ECS
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           repo: pybot
           tag: '${CIRCLE_BRANCH}'
           dockerfile: docker/Dockerfile
@@ -52,7 +52,7 @@ workflows:
           container-image-name-updates: 'container=pybot,tag=${CIRCLE_BRANCH}'
           verify-revision-is-deployed: true
           requires:
-            - aws-ecr/build_and_push_image
+            - aws-ecr/build-and-push-image
           filters:
             branches:
               only:
@@ -64,7 +64,7 @@ jobs:
     docker:
       - image: circleci/python:3.7.1
         environment: # environment variables for primary container
-          PIPENV_VENV_IN_PROJECT: true
+          PIPENV_VENV_IN_PROJECT: "true"
 
     steps:
       - checkout


### PR DESCRIPTION
I'm not entirely sure why this deploy failed, but being that it's trying to use Python 2.7, I think it's fair to say that this orb probably needs to be updated. Updating to the latest because the docs for 7.3 still have all of the keys that we're using so I don't think any breaking changes affected us (other than breaking our build when we didn't upgrade). 🤞🏻 that this "just fixes it"

![Screen Shot 2021-12-22 at 4 48 58 PM](https://user-images.githubusercontent.com/2008701/147163646-d5e02e59-92f3-4f12-b40e-1bffb21db4ec.png)