### PR TITLE
Upgrade pip so cryptography will build successfully

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,8 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY poetry.lock pyproject.toml ./
 
+RUN pip install pip==21.3.1
+
 RUN pip install poetry && \
     poetry config virtualenvs.create false && \
     poetry install --no-dev --no-interaction


### PR DESCRIPTION
Fixes this [failing build](https://app.circleci.com/pipelines/github/OperationCode/operationcode-pybot/390/workflows/e10fe3ba-b025-488b-9f0b-9cb7fa6e1f8a/jobs/617)


![Screen Shot 2021-12-22 at 6 26 55 PM](https://user-images.githubusercontent.com/2008701/147169792-b35e8f63-f5ee-4731-ac01-388234f167db.png)

